### PR TITLE
Check existence of start/stop parameters

### DIFF
--- a/lib/miniprofiler.js
+++ b/lib/miniprofiler.js
@@ -406,6 +406,10 @@ function describePerformance(root, request) {
 }
 
 function diff(start, stop){
+  if (!start || !stop) {
+    return 0;
+  }
+
   var deltaSecs = stop[0] - start[0];
   var deltaNanoSecs = stop[1] - start[1];
 


### PR DESCRIPTION
This should handle the case where the `stop` parameter is null/undefined