### PR TITLE
Use __dirname instead of module.filename to better support bundlers.

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -5,7 +5,7 @@ const fileStore = { };
 const fs = require('fs');
 const path = require('path');
 const _ = require('./utils.js');
-const includesDir = path.join(path.dirname(module.filename), '../ui');
+const includesDir = path.join(__dirname, '../ui');
 
 const readFile = (name, callback) => {
   if (fileStore[name]) {


### PR DESCRIPTION
Hello, and thanks for supporting the MiniProfiler package!

I ran into an issue with path resolution for the HTML templates in the `ui` folder, specifically related to `module.filename` not resolving correctly under webpack.

This change doesn't alter current behavior and all tests continue to pass.