### PR TITLE
Don't run step if miniprofiler doesn't exist

### DIFF
--- a/lib/middlewares/express.js
+++ b/lib/middlewares/express.js
@@ -19,9 +19,14 @@ module.exports = {
         var render = res.render;
         res.render = function() {
           var renderArguments = arguments;
-          req.miniprofiler.step(`Render: ${arguments[0]}`, function() {
+          if (req.miniprofiler) {
+            req.miniprofiler.step(`Render: ${arguments[0]}`, function() {
+              render.apply(res, renderArguments);
+            });
+          }
+          else {
             render.apply(res, renderArguments);
-          });
+          }
         };
 
         if (!handled)


### PR DESCRIPTION
For some reason, miniprofiler object isn't accessible in middleware in some conditions